### PR TITLE
Migrate off probot-CLA to new GitHub Action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,7 +2,7 @@ name: Contributor License Agreement (CLA)
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
Hello 👋

We are deprecating probot usage, so all Shopify repos should be migrated to use new [GitHub CLA Action](https://github.com/Shopify/shopify-cla-action).

You can see how this works in [vscode-shopify-ruby repo](https://github.com/Shopify/vscode-shopify-ruby/pull/171).

If you have any questions, please reach us [on Slack](https://shopify.slack.com/archives/C03FLDE8SLB).

### After you merge this PR, make sure to update branch protection settings (if you have any):

1. Go to `Settings > Branches > Edit main (or any default) branch`
2. Remove the CLA check from probot (click `x`): <img width="733" alt="image" src="https://user-images.githubusercontent.com/899452/179303783-1b5b8084-3e91-4b72-b857-916b63cdb07c.png">
3. Add CLA check from GitHub action: <img width="731" alt="image" src="https://user-images.githubusercontent.com/899452/179303840-1257d0bf-ee34-4f35-b461-a5956d79d2e1.png">

** In order for the cheak to appear on the list, the workflow should be ran for at least 1 time, so after you merge this PR, add comment with text `signed`, then refresh the settings page.

### How to trigger workflow on existing PRs:

There are few ways how to start the check on PRs created before this change:

a) Close and reopen PR:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/899452/181010337-3aa0a501-3016-463e-9da8-a154beab0c01.png">
b) Push empty commit to trigger the events: `git commit --allow-empty -m "wakey wakey GitHub Actions"`