### PR TITLE
Allow HTTP scheme in Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [#212](https://github.com/Shopify/shopify-api-php/pull/212) Allow a scheme in the `Context::$HOST_NAME` URL to enable support for HTTP apps
+
 ## v3.1.0 - 2022-08-04
 
 - [#209](https://github.com/Shopify/shopify-api-php/pull/209) Add `getEmbeddedAppUrl` utils method to load the embedded app in the right Shopify host

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,18 +12,18 @@ The library is available on [Packagist](https://packagist.org/packages/shopify/s
 
 The first thing your app will need to do to use this library is to set up your configurations. You can do that by calling the `Shopify\Context::initialize` method, which accepts the following settings:
 
-| Param | Type | Required? | Default | Notes |
-| --- | --- | :---: | :---: | --- |
-| `apiKey` | `string` | Yes | - | App API key from the Partners dashboard |
-| `apiSecretKey` | `string` | Yes | - | App API secret from the Partners dashboard |
-| `scopes` | `string \| array` | Yes | - | App scopes |
-| `hostName` | `string` | Yes | - | App host name e.g. `my-app.my-domain.ca` |
-| `sessionStorage` | `SessionStorage` | Yes | - | Session storage strategy. Read our [notes on session handling](issues.md#notes-on-session-handling) for more information |
-| `apiVersion` | `string` | No | `'unstable'` | App API version, defaults to unstable |
-| `isEmbeddedApp` | `bool` | No | `true` | Whether the app is an embedded app |
-| `isPrivateApp` | `bool` | No | `false` | Whether the app is a private app |
-| `userAgentPrefix` | `string` | No | - | Prefix for user agent header sent with a request |
-| `logger` | `LoggerInterface` | No | - | App logger, so the library can add its own logs to it. Must implement the [PSR-3](https://www.php-fig.org/psr/psr-3/) `Psr\Log\LoggerInterface` interface from the `psr/log` package |
+| Param             | Type              | Required? |   Default    | Notes                                                                                                                                                                                |
+| ----------------- | ----------------- | :-------: | :----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `apiKey`          | `string`          |    Yes    |      -       | App API key from the Partners dashboard                                                                                                                                              |
+| `apiSecretKey`    | `string`          |    Yes    |      -       | App API secret from the Partners dashboard                                                                                                                                           |
+| `scopes`          | `string \| array` |    Yes    |      -       | App scopes                                                                                                                                                                           |
+| `hostName`        | `string`          |    Yes    |      -       | App host name e.g. `my-app.my-domain.ca`. You may optionally include `https://` or `http://` to determine which scheme to use                                                        |
+| `sessionStorage`  | `SessionStorage`  |    Yes    |      -       | Session storage strategy. Read our [notes on session handling](issues.md#notes-on-session-handling) for more information                                                             |
+| `apiVersion`      | `string`          |    No     | `'unstable'` | App API version, defaults to unstable                                                                                                                                                |
+| `isEmbeddedApp`   | `bool`            |    No     |    `true`    | Whether the app is an embedded app                                                                                                                                                   |
+| `isPrivateApp`    | `bool`            |    No     |   `false`    | Whether the app is a private app                                                                                                                                                     |
+| `userAgentPrefix` | `string`          |    No     |      -       | Prefix for user agent header sent with a request                                                                                                                                     |
+| `logger`          | `LoggerInterface` |    No     |      -       | App logger, so the library can add its own logs to it. Must implement the [PSR-3](https://www.php-fig.org/psr/psr-3/) `Psr\Log\LoggerInterface` interface from the `psr/log` package |
 
 You should call this method as early as possible in your application, as none of the library's features are available until it is initialized. Below is an example call to `initialize`:
 

--- a/src/Auth/OAuth.php
+++ b/src/Auth/OAuth.php
@@ -89,7 +89,7 @@ class OAuth
         $query = [
             'client_id' => Context::$API_KEY,
             'scope' => Context::$SCOPES->toString(),
-            'redirect_uri' => 'https://' . Context::$HOST_NAME . $redirectPath,
+            'redirect_uri' => Context::$HOST_SCHEME . '://' . Context::$HOST_NAME . $redirectPath,
             'state' => $session->getState(),
             'grant_options[]' => $grantOptions,
         ];

--- a/tests/Auth/OAuthTest.php
+++ b/tests/Auth/OAuthTest.php
@@ -60,8 +60,10 @@ final class OAuthTest extends BaseTestCase
     /**
      * @dataProvider validBeginProvider
      */
-    public function testValidBegin($isOnline)
+    public function testValidBegin($isOnline, $hostScheme)
     {
+        Context::$HOST_SCHEME = $hostScheme;
+
         /** @var OAuthCookie[] */
         $cookiesSet = [];
         $cookieCallback = function (OAuthCookie $cookie) use (&$cookiesSet) {
@@ -91,7 +93,7 @@ final class OAuthTest extends BaseTestCase
         $generatedState = Context::$SESSION_STORAGE->loadSession($cookieSessionId)->getState();
         $this->assertEquals(
             // phpcs:ignore
-            "https://shopname.myshopify.com/admin/oauth/authorize?client_id=ash&scope=sleepy%2Ckitty&redirect_uri=https%3A%2F%2Fwww.my-friends-cats.com%2Fredirect&state={$generatedState}&grant_options%5B%5D=$grantOptions",
+            "https://shopname.myshopify.com/admin/oauth/authorize?client_id=ash&scope=sleepy%2Ckitty&redirect_uri=$hostScheme%3A%2F%2Fwww.my-friends-cats.com%2Fredirect&state={$generatedState}&grant_options%5B%5D=$grantOptions",
             $returnUrl
         );
     }
@@ -99,8 +101,10 @@ final class OAuthTest extends BaseTestCase
     public function validBeginProvider(): array
     {
         return [
-            'Online'  => [true],
-            'Offline' => [false],
+            'Online, HTTPS'  => [true, 'https'],
+            'Online, HTTP'  => [true, 'http'],
+            'Offline, HTTPS' => [false, 'https'],
+            'Offline, HTTP' => [false, 'http'],
         ];
     }
 

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -21,6 +21,7 @@ final class ContextTest extends BaseTestCase
         $this->assertEquals('steffi', Context::$API_SECRET_KEY);
         $this->assertEquals(new Scopes(['sleepy', 'kitty']), Context::$SCOPES);
         $this->assertEquals('my-friends-cats', Context::$HOST_NAME);
+        $this->assertEquals('https', Context::$HOST_SCHEME);
 
         // This should not trigger the exception
         Context::throwIfUninitialized();
@@ -114,5 +115,31 @@ final class ContextTest extends BaseTestCase
 
         Context::log('Emerg log', LogLevel::EMERGENCY);
         $this->assertTrue($testLogger->hasEmergency('Emerg log'));
+    }
+
+    /**
+     * @dataProvider canSetHostSchemeProvider
+     */
+    public function testCanSetHostScheme($host, $expectedScheme)
+    {
+        Context::initialize('ash', 'steffi', ['sleepy', 'kitty'], $host, new MockSessionStorage());
+
+        $this->assertEquals('my-friends-cats.io', Context::$HOST_NAME);
+        $this->assertEquals($expectedScheme, Context::$HOST_SCHEME);
+    }
+
+    public function canSetHostSchemeProvider()
+    {
+        return [
+            ['my-friends-cats.io', 'https'],
+            ['https://my-friends-cats.io', 'https'],
+            ['http://my-friends-cats.io', 'http'],
+        ];
+    }
+
+    public function testFailsOnInvalidHost()
+    {
+        $this->expectException(\Shopify\Exception\InvalidArgumentException::class);
+        Context::initialize('ash', 'steffi', ['sleepy', 'kitty'], 'not-a-host-!@#$%^&*()', new MockSessionStorage());
     }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

In order to run the CLI command `dev --no-tunnel`, we need to make the library and template capable of using the HTTP scheme.

### WHAT is this pull request doing?

Removing any assumptions we had of the scheme being `https://`, and replacing it with a `Context::$HOST_SCHEME` that can be derived from `Context::$HOST_NAME`, if passed. We still default to HTTPS so this change does not affect existing apps.

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have updated the documentation for public APIs from the library (if applicable)
