### PR TITLE
Add leeway when decoding JWT session tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [#213](https://github.com/Shopify/shopify-api-php/pull/213) Add 10s leeway when decoding session token JWTs
 - [#211](https://github.com/Shopify/shopify-api-php/pull/211) Change requirement of `psr/log` from `^1.1` to `^1.1 || ^2.0 || ^3.0`
 - [#210](https://github.com/Shopify/shopify-api-php/pull/210) Add `ext-json` as a dependency in `composer.json`
 - [#212](https://github.com/Shopify/shopify-api-php/pull/212) Allow a scheme in the `Context::$HOST_NAME` URL to enable support for HTTP apps

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -157,6 +157,7 @@ final class Utils
      */
     public static function decodeSessionToken(string $jwt): array
     {
+        JWT::$leeway = 10;
         $payload = JWT::decode($jwt, Context::$API_SECRET_KEY, array('HS256'));
         return (array) $payload;
     }


### PR DESCRIPTION
### WHY are these changes introduced?

We didn't have any leeway when parsing session token JWTs, but there are cases where there might be small discrepancy between the client and server clocks, and we end up failing to validate the token.

### WHAT is this pull request doing?

Add 10s of leeway to ensure we don't fail on actually valid tokens.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
