### PR TITLE
Fix host name to support ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [#218](https://github.com/Shopify/shopify-api-php/pull/218) Fix issue that failed when setting `Context::$HOST_NAME` with a port
+
 ## v3.2.0 - 2022-09-21
 
 - [#213](https://github.com/Shopify/shopify-api-php/pull/213) Add 10s leeway when decoding session token JWTs

--- a/src/Context.php
+++ b/src/Context.php
@@ -114,10 +114,12 @@ class Context
             throw new InvalidArgumentException("Invalid host: $hostName");
         }
 
+        $host = $parsedUrl["host"] . (array_key_exists("port", $parsedUrl) ? ":{$parsedUrl["port"]}" : "");
+
         self::$API_KEY = $apiKey;
         self::$API_SECRET_KEY = $apiSecretKey;
         self::$SCOPES = $authScopes;
-        self::$HOST_NAME = $parsedUrl["host"];
+        self::$HOST_NAME = $host;
         self::$HOST_SCHEME = $parsedUrl["scheme"];
         self::$SESSION_STORAGE = $sessionStorage;
         self::$HTTP_CLIENT_FACTORY = new HttpClientFactory();

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -119,20 +119,22 @@ final class ContextTest extends BaseTestCase
     /**
      * @dataProvider canSetHostSchemeProvider
      */
-    public function testCanSetHostScheme($host, $expectedScheme)
+    public function testCanSetHostScheme($host, $expectedScheme, $expectedHost)
     {
         Context::initialize('ash', 'steffi', ['sleepy', 'kitty'], $host, new MockSessionStorage());
 
-        $this->assertEquals('my-friends-cats.io', Context::$HOST_NAME);
+        $this->assertEquals($expectedHost, Context::$HOST_NAME);
         $this->assertEquals($expectedScheme, Context::$HOST_SCHEME);
     }
 
     public function canSetHostSchemeProvider()
     {
         return [
-            ['my-friends-cats.io', 'https'],
-            ['https://my-friends-cats.io', 'https'],
-            ['http://my-friends-cats.io', 'http'],
+            ['my-friends-cats.io', 'https', 'my-friends-cats.io'],
+            ['https://my-friends-cats.io', 'https', 'my-friends-cats.io'],
+            ['http://my-friends-cats.io', 'http', 'my-friends-cats.io'],
+            ['http://localhost', 'http', 'localhost'],
+            ['http://localhost:1234', 'http', 'localhost:1234'],
         ];
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

We added support to run the library using HTTP, but I failed to realize the `parse_url` doesn't include the port in the host name.

### WHAT is this pull request doing?

Ensuring that the port is included in `Context::$HOST_NAME` when we're parsing it.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change