### PR TITLE
Add support for global custom shopify domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [#222](https://github.com/Shopify/shopify-api-php/pull/222) Add support for `Context::$CUSTOM_SHOP_DOMAINS` setting
+
 ## v4.0.0 - 2022-10-04
 
 - [#221](https://github.com/Shopify/shopify-api-php/pull/221) ⚠️ [Breaking] Add REST resources for October 2022 API version, remove support and REST resources for October 2021 (`2021-10`) API version

--- a/src/Context.php
+++ b/src/Context.php
@@ -40,6 +40,8 @@ class Context
     public static $USER_AGENT_PREFIX = null;
     /** @var LoggerInterface|null */
     public static $LOGGER = null;
+    /** @var string[] */
+    public static $CUSTOM_SHOP_DOMAINS = null;
 
     /** @var int */
     public static $RETRY_TIME_IN_SECONDS = 1;
@@ -63,6 +65,7 @@ class Context
      * @param string               $userAgentPrefix                 Prefix for user agent header sent with a request
      * @param LoggerInterface|null $logger                          App logger, so the library can add its own logs to
      *                                                              it
+     * @param string[]             $customShopDomains               One or more regexps to use when validating domains
      *
      * @throws \Shopify\Exception\MissingArgumentException
      */
@@ -77,7 +80,8 @@ class Context
         bool $isPrivateApp = false,
         string $privateAppStorefrontAccessToken = null,
         string $userAgentPrefix = '',
-        LoggerInterface $logger = null
+        LoggerInterface $logger = null,
+        array $customShopDomains = []
     ): void {
         $authScopes = new Scopes($scopes);
 
@@ -129,6 +133,7 @@ class Context
         self::$PRIVATE_APP_STOREFRONT_ACCESS_TOKEN = $privateAppStorefrontAccessToken;
         self::$USER_AGENT_PREFIX = $userAgentPrefix;
         self::$LOGGER = $logger;
+        self::$CUSTOM_SHOP_DOMAINS = $customShopDomains;
 
         self::$IS_INITIALIZED = true;
     }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -32,7 +32,20 @@ final class Utils
     {
         $name = trim(strtolower($shop));
 
-        $allowedDomainsRegexp = $myshopifyDomain ? "($myshopifyDomain)" : "(myshopify.com|myshopify.io)";
+        if ($myshopifyDomain) {
+            $allowedDomains = [preg_replace("/^\*?\.?(.*)/", "$1", $myshopifyDomain)];
+        } else {
+            $allowedDomains = ["myshopify.com", "myshopify.io"];
+        }
+
+        if (Context::$CUSTOM_SHOP_DOMAINS) {
+            $allowedDomains = array_merge(
+                $allowedDomains,
+                preg_replace("/^\*?\.?(.*)/", "$1", Context::$CUSTOM_SHOP_DOMAINS)
+            );
+        }
+
+        $allowedDomainsRegexp = "(" . implode("|", $allowedDomains) . ")";
 
         if (!preg_match($allowedDomainsRegexp, $name) && (strpos($name, ".") === false)) {
             $name .= '.' . ($myshopifyDomain ?? 'myshopify.com');

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -6,6 +6,7 @@ namespace ShopifyTest;
 
 use Psr\Log\LogLevel;
 use ReflectionClass;
+use Shopify\ApiVersion;
 use Shopify\Auth\Scopes;
 use Shopify\Context;
 use ShopifyTest\Auth\MockSessionStorage;
@@ -142,5 +143,27 @@ final class ContextTest extends BaseTestCase
     {
         $this->expectException(\Shopify\Exception\InvalidArgumentException::class);
         Context::initialize('ash', 'steffi', ['sleepy', 'kitty'], 'not-a-host-!@#$%^&*()', new MockSessionStorage());
+    }
+
+    public function testCanSetCustomShopDomains()
+    {
+        $domains = ['*.special-domain-1.io', '*.special-domain-2.io'];
+
+        Context::initialize(
+            'ash',
+            'steffi',
+            ['sleepy', 'kitty'],
+            'my-friends-cats',
+            new MockSessionStorage(),
+            ApiVersion::LATEST,
+            true,
+            false,
+            null,
+            '',
+            null,
+            $domains
+        );
+
+        $this->assertEquals($domains, Context::$CUSTOM_SHOP_DOMAINS);
     }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -28,16 +28,16 @@ final class UtilsTest extends BaseTestCase
 
     public function testSanitizeShopDomainOnBadShopDomains()
     {
-        $this->assertEquals(null, Utils::sanitizeShopDomain('myshop.com'));
-        $this->assertEquals(null, Utils::sanitizeShopDomain('myshopify.com'));
-        $this->assertEquals(null, Utils::sanitizeShopDomain('shopify.com'));
-        $this->assertEquals(null, Utils::sanitizeShopDomain('my shop'));
-        $this->assertEquals(null, Utils::sanitizeShopDomain('store.myshopify.com.evil.com'));
-        $this->assertEquals(null, Utils::sanitizeShopDomain('/foo/bar'));
-        $this->assertEquals(null, Utils::sanitizeShopDomain('/foo.myshopify.io.evil.ru'));
-        $this->assertEquals(null, Utils::sanitizeShopDomain('%0a123.myshopify.io'));
-        $this->assertEquals(null, Utils::sanitizeShopDomain('foo.bar.myshopify.io'));
-        $this->assertEquals(null, Utils::sanitizeShopDomain('https://my-shop.myshopify.com', 'myshopify.io'));
+        $this->assertNull(Utils::sanitizeShopDomain('myshop.com'));
+        $this->assertNull(Utils::sanitizeShopDomain('myshopify.com'));
+        $this->assertNull(Utils::sanitizeShopDomain('shopify.com'));
+        $this->assertNull(Utils::sanitizeShopDomain('my shop'));
+        $this->assertNull(Utils::sanitizeShopDomain('store.myshopify.com.evil.com'));
+        $this->assertNull(Utils::sanitizeShopDomain('/foo/bar'));
+        $this->assertNull(Utils::sanitizeShopDomain('/foo.myshopify.io.evil.ru'));
+        $this->assertNull(Utils::sanitizeShopDomain('%0a123.myshopify.io'));
+        $this->assertNull(Utils::sanitizeShopDomain('foo.bar.myshopify.io'));
+        $this->assertNull(Utils::sanitizeShopDomain('https://my-shop.myshopify.com', 'myshopify.io'));
     }
 
     public function testSanitizeShopDomainOnCustomShopDomains()
@@ -57,6 +57,35 @@ final class UtilsTest extends BaseTestCase
             'myshopify.io'
         ));
         $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain(' MY-SHOP ', 'myshopify.io'));
+    }
+
+    /**
+     * @dataProvider sanitizeShopWithCustomDomainsProvider
+     */
+    public function testSanitizeShopWithCustomDomains($domains, $test, $expected)
+    {
+        Context::$CUSTOM_SHOP_DOMAINS = $domains;
+
+        $this->assertEquals($expected, Utils::sanitizeShopDomain($test));
+    }
+
+    public function sanitizeShopWithCustomDomainsProvider()
+    {
+        return [
+            [
+                ['*.special-domain-1.io', '.special-domain-2.io'],
+                'my-shop.special-domain-1.io',
+                'my-shop.special-domain-1.io'
+            ],
+            [
+                ['*.special-domain-1.io', '.special-domain-2.io'],
+                'my-shop.special-domain-2.io',
+                'my-shop.special-domain-2.io'
+            ],
+            [['.special-domain-1.io'], 'my-shop.special-domain-1.io', 'my-shop.special-domain-1.io'],
+            [['special-domain-1.io'], 'my-shop.special-domain-1.io', 'my-shop.special-domain-1.io'],
+            [['*.special-domain-1.io', '.special-domain-2.io'], 'my-shop.special-domain-3.io', null],
+        ];
     }
 
     public function testValidHmac()


### PR DESCRIPTION
### WHY are these changes introduced?

Sometimes when testing, we might need different domains than the production ones.

### WHAT is this pull request doing?

Adding support for a new `Context` setting, to allow callers to add to the list of allowed domains globally to make it easier to test things.

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
