### PR TITLE
Add `not_planned` reason to Stale Workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,3 +30,4 @@ jobs:
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           exempt-issue-labels: "feature request"
+          close-issue-reason: "not_planned"


### PR DESCRIPTION
### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->
Issues that were closed by our stale workflow were getting closed as "complete". This might be confusing so we should close as `not_planned`.

[We are also doing this in `shopify_app`](https://github.com/Shopify/shopify_app/pull/1582)

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
