### PR TITLE
Update shopify.dev links to include /docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 Submitting Issues
 -----------------
 
-Please open an issue here if you encounter a specific bug with this API client library or if something is documented here https://shopify.dev/apps but is missing from this package.
+Please open an issue here if you encounter a specific bug with this API client library or if something is documented here https://shopify.dev/docs/apps but is missing from this package.
 
 General questions about the Shopify API and usage of this package (not necessarily a bug) should be posted on the [Shopify forums](https://community.shopify.com/c/partners-and-developers/ct-p/appdev).
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 <!-- ![Build Status]() -->
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-This library provides support for PHP [Shopify](https://www.shopify.com) apps to access the [Shopify Admin API](https://shopify.dev/docs/admin-api), by making it easier to perform the following actions:
+This library provides support for PHP [Shopify](https://www.shopify.com) apps to access the [Shopify Admin API](https://shopify.dev/docs/api/admin), by making it easier to perform the following actions:
 
-- Creating [online](https://shopify.dev/concepts/about-apis/authentication#online-access) or [offline](https://shopify.dev/concepts/about-apis/authentication#offline-access) access tokens for the Admin API via OAuth
-- Making requests to the [REST API](https://shopify.dev/docs/admin-api/rest/reference)
-- Making requests to the [GraphQL API](https://shopify.dev/docs/admin-api/graphql/reference)
+- Creating [online](https://shopify.dev/docs/apps/auth#online-access) or [offline](https://shopify.dev/docs/apps/auth#offline-access) access tokens for the Admin API via OAuth
+- Making requests to the [REST API](https://shopify.dev/docs/api/admin-rest)
+- Making requests to the [GraphQL API](https://shopify.dev/docs/api/admin-graphql)
 - Registering/processing webhooks
 
-In addition to the Admin API, this library also allows querying the [Storefront API](https://shopify.dev/docs/storefront-api).
+In addition to the Admin API, this library also allows querying the [Storefront API](https://shopify.dev/docs/api/storefront).
 
 This library can be used in any application that has a PHP backend, since it doesn't rely on any specific framework—you can include it alongside your preferred stack and only use the features that you need to build your app.
 

--- a/docs/usage/oauth.md
+++ b/docs/usage/oauth.md
@@ -1,6 +1,6 @@
 # Performing OAuth
 
-Once the library is set up for your project, you'll be able to use it to start adding functionality to your app. The first thing your app will need to do is to obtain an access token to the Admin API by performing the OAuth process. You can read our [OAuth tutorial](https://shopify.dev/tutorials/authenticate-with-oauth) to learn more about the process.
+Once the library is set up for your project, you'll be able to use it to start adding functionality to your app. The first thing your app will need to do is to obtain an access token to the Admin API by performing the OAuth process. You can read our [OAuth overview](https://shopify.dev/docs/apps/auth/oauth) to learn more about the process.
 
 Once you've implemented these actions in your app, please make sure to read our [notes on session handling](../issues.md#notes-on-session-handling).
 
@@ -57,7 +57,7 @@ The `Session` object provides the following methods to expose its data:
 | `getState` | `string` | The `state` of the session. This is mainly used for OAuth. |
 | `getScope` | `string \| null` | The effective API scopes enabled for this session. |
 | `getExpires` | `DateTime \| null` | The expiration date of the session, or null if it is offline. |
-| `isOnline` | `bool` | Whether the session is [online or offline](https://shopify.dev/concepts/about-apis/authentication#api-access-modes). |
+| `isOnline` | `bool` | Whether the session is [online or offline](https://shopify.dev/docs/apps/auth#api-access-modes). |
 | `getAccessToken` | `string \| null` | The Admin API access token for the session. |
 | `getOnlineAccessInfo` | `AccessTokenOnlineUserInfo \| null` | The data for the user associated with this session. Only applies to online sessions. |
 

--- a/docs/usage/rest.md
+++ b/docs/usage/rest.md
@@ -2,11 +2,11 @@
 
 REST Admin API lets you build apps and other integrations for the Shopify admin using REST. With the API, you can create apps that offer functionality at every stage of a store's operation, including shipping, fulfillment, and product management.
 
-You can read our [REST Admin API](https://shopify.dev/docs/admin-api/getting-started#rest-admin-api) documentation and [REST Admin API reference](https://shopify.dev/docs/admin-api/rest/reference) for more information.
+You can read our [REST Admin API](https://shopify.dev/docs/api/admin/getting-started#rest-admin-api) documentation and [REST Admin API reference](https://shopify.dev/docs/api/admin-rest) for more information.
 
 ## Making your first REST request
 
-REST Admin API endpoints are organized by [resource](https://shopify.dev/docs/admin-api/rest/reference#selecting-apis-for-your-app) . You'll need to use different API endpoints depending on the service that your app provides. There are two different ways of doing that with this library:
+REST Admin API endpoints are organized by [resource](https://shopify.dev/docs/api/admin/rest/reference#selecting-apis-for-your-app) . You'll need to use different API endpoints depending on the service that your app provides. There are two different ways of doing that with this library:
 * [REST resources](#rest-resources)
 * [REST client](#rest-client)
 
@@ -14,7 +14,7 @@ REST Admin API endpoints are organized by [resource](https://shopify.dev/docs/ad
 
 REST resources are objects that represent the REST endpoints in the Admin API. This library provides classes for the endpoints in all supported versions of the API. We don't provide classes for the `unstable` version because it may change at any point, which would cause the resource classes to become outdated.
 
-The resource classes will provide methods for all endpoints described in [the REST reference docs](https://shopify.dev/api/admin-rest). Please see the references for how to use a specific resource.
+The resource classes will provide methods for all endpoints described in [the REST reference docs](https://shopify.dev/docs/api/admin-rest). Please see the references for how to use a specific resource.
 
 ### REST client
 
@@ -42,7 +42,7 @@ This request returns an instance of `Shopify\Clients\RestResponse`. The response
 
 ## Pagination
 
-REST endpoints support cursor-based pagination. When you send a request to a REST endpoint that supports cursor-based pagination, the response body returns the first page of results, and a response header returns links to the next page, and the previous page of results (if applicable). For more information check [Make paginated requests to the REST Admin API](https://shopify.dev/tutorials/make-paginated-requests-to-rest-admin-api) tutorial.
+REST endpoints support cursor-based pagination. When you send a request to a REST endpoint that supports cursor-based pagination, the response body returns the first page of results, and a response header returns links to the next page, and the previous page of results (if applicable). For more information check [Make paginated requests to the REST Admin API](https://shopify.dev/docs/api/usage/pagination-rest).
 
 `Shopify\Clients\Rest` helps you manage pagination by giving you the information you need. The response object of a `get` operation includes pagination information. To retrieve the pagination information call `$result->getPageInfo()`.
 

--- a/docs/usage/storefront.md
+++ b/docs/usage/storefront.md
@@ -1,10 +1,10 @@
 # Make a Storefront API call
 
-This library also allows you to send GraphQL requests to the [Shopify Storefront API](https://shopify.dev/docs/storefront-api). To do that, you can use the `Shopify\Clients\Storefront` class using the current shop and an access token.
+This library also allows you to send GraphQL requests to the [Shopify Storefront API](https://shopify.dev/docs/api/storefront). To do that, you can use the `Shopify\Clients\Storefront` class using the current shop and an access token.
 
-⚠️ This API limits request rates based on the IP address that calls it, which will be your server's address for all requests made by the library. The API uses a leaky bucket algorithm, with a default bucket size of 60 seconds of request processing time (minimum 0.5s per request), with a leak rate of 1/s. Learn more about [rate limits](https://shopify.dev/api/usage/rate-limits).
+⚠️ This API limits request rates based on the IP address that calls it, which will be your server's address for all requests made by the library. The API uses a leaky bucket algorithm, with a default bucket size of 60 seconds of request processing time (minimum 0.5s per request), with a leak rate of 1/s. Learn more about [rate limits](https://shopify.dev/docs/api/usage/rate-limits).
 
-You can obtain Storefront API access tokens for both private apps and sales channels. Please read [our documentation](https://shopify.dev/docs/storefront-api/getting-started) to learn more about Storefront Access Tokens. For example, sales channels can create new Storefront Access Tokens by running the following code **with an offline Admin API session**:
+You can obtain Storefront API access tokens for both private apps and sales channels. Please read [our documentation](https://shopify.dev/docs/custom-storefronts/building-with-the-storefront-api/products-collections/getting-started) to learn more about Storefront Access Tokens. For example, sales channels can create new Storefront Access Tokens by running the following code **with an offline Admin API session**:
 
 ```php
 // Create a REST client from your offline session

--- a/src/Webhooks/Topics.php
+++ b/src/Webhooks/Topics.php
@@ -8,7 +8,7 @@ namespace Shopify\Webhooks;
  * Contains a list of known webhook topics.
  *
  * For an up-to-date list of topics, you can visit
- * https://shopify.dev/docs/admin-api/graphql/reference/events/webhooksubscriptiontopic
+ * https://shopify.dev/docs/api/admin-graphql/latest/enums/webhooksubscriptiontopic
  */
 final class Topics
 {


### PR DESCRIPTION
### WHY are these changes introduced?

Much of the api and app related content has been moved under /docs on the Shopify Dev site. This updates the links to point to the new locations.

### WHAT is this pull request doing?

See above ☝🏻 