### PR TITLE
Refactored query string building to account for array handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [#269](https://github.com/Shopify/shopify-api-php/pull/269) [bugfix] Refactored query string building to account for Shopify-specific array format
 - [#236](https://github.com/Shopify/shopify-api-php/pull/236) [bugfix] Correct requirements in `composer.json`
 - [#262](https://github.com/Shopify/shopify-api-php/pull/262) ⚠️ [Breaking] Added support for PHP 8.2, and removed support for PHP 7.4
 - [#264](https://github.com/Shopify/shopify-api-php/pull/264) [Patch] Remove support for currently-non-existent versions of PHP (8.3+)

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -87,6 +87,58 @@ final class UtilsTest extends BaseTestCase
         ];
     }
 
+    /**
+     * @dataProvider buildQueryStringProvider
+     */
+    public function testBuildQueryString($params, $queryString)
+    {
+        $this->assertEquals($queryString, Utils::buildQueryString($params));
+    }
+
+    public function buildQueryStringProvider()
+    {
+        return [
+            [
+                [],
+                ''
+            ],
+            [
+                [
+                    'hmac' => 'ThisShouldNotAppearInTheString',
+                    'foo' => 'ThisShould',
+                    'bar' => 'AsShouldThis',
+                ],
+                'foo=ThisShould&bar=AsShouldThis'
+            ],
+            [
+                [
+                    'hmac' => 'ThisShouldNotAppearInTheString',
+                    'someArray' => [
+                      'foo',
+                      'bar',
+                      1,
+                    ],
+                ],
+                'someArray=%5B%22foo%22%2C%22bar%22%2C%221%22%5D' // URLEncoded for: ["foo","bar","1"]
+            ],
+        ];
+    }
+
+    public function testEmptyHmac()
+    {
+        $this->assertEquals(false, Utils::validateHmac(
+            [],
+            'I AM SECRET'
+        ));
+
+        $this->assertEquals(false, Utils::validateHmac(
+            [
+                'hmac' => 'SomeHash',
+            ],
+            ''
+        ));
+    }
+
     public function testValidHmac()
     {
         // phpcs:ignore


### PR DESCRIPTION
### WHY are these changes introduced?

Duplicates https://github.com/Shopify/shopify-api-php/pull/232, as described there:
> The function \Shopify\Utils::validateHmac() does not work when query parameters contain array values, this is because http_build_query will transform array values to a different format than Shopify uses when generating the hash, see https://community.shopify.com/c/shopify-apis-and-sdks/hmac-calculation-vs-ids-arrays/m-p/261154.

### WHAT is this pull request doing?

This PR outsources the generation of the query string to a dedicated function that takes care of all the Shopify-specifics for this case: namely ensuring we do not include the HMAC in the string and use the custom format for arrays.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
