### PR TITLE
Use new CLI env variable names

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -29,8 +29,8 @@ You should call this method as early as possible in your application, as none of
 
 ```php
 Context::initialize(
-    apiKey: $_ENV['SHOPIFY_API_KEY'],
-    apiSecretKey: $_ENV['SHOPIFY_API_SECRET'],
+    apiKey: $_ENV['SHOPIFY_APP_API_KEY'],
+    apiSecretKey: $_ENV['SHOPIFY_APP_API_SECRET'],
     scopes: $_ENV['SHOPIFY_APP_SCOPES'],
     hostName: $_ENV['SHOPIFY_APP_HOST_NAME'],
     sessionStorage: new FileSessionStorage('/tmp/php_sessions'),


### PR DESCRIPTION
### WHY are these changes introduced?

With https://github.com/Shopify/shopify-dev/pull/33718, the CLI will deprecate some env var names. While they will still be present so previous apps won't break, we should migrate new apps as soon as possible to the new format.

### WHAT is this pull request doing?

Updating the README instructions to reflect the new names.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation for public APIs from the library (if applicable)
