### PR TITLE
Fix the issue "Get Current Session ID process from Post Purchase Extension Token"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Fix the issue "Get Current Session ID process from Post Purchase Extension Token" [bugfix] 
+- PATCH: Fix the issue "Get Current Session ID process from Post Purchase Extension Token"
 
 ## v5.0.0 - 2023-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Fix the issue "Get Current Session ID process from Post Purchase Extension Token" [bugfix] 
 
 ## v5.0.0 - 2023-05-10
 

--- a/src/Auth/OAuth.php
+++ b/src/Auth/OAuth.php
@@ -12,6 +12,7 @@ use Shopify\Exception\CookieNotFoundException;
 use Shopify\Exception\CookieSetException;
 use Shopify\Exception\HttpRequestException;
 use Shopify\Exception\InvalidArgumentException;
+use Shopify\Exception\InvalidJwtPayloadException;
 use Shopify\Exception\InvalidOAuthException;
 use Shopify\Exception\MissingArgumentException;
 use Shopify\Exception\OAuthSessionNotFoundException;
@@ -232,7 +233,15 @@ class OAuth
                 }
 
                 $jwtPayload = Utils::decodeSessionToken($matches[1]);
-                $shop = preg_replace('/^https:\/\//', '', $jwtPayload['dest']);
+
+                if (!empty($jwtPayload['dest'])) {
+                    $shop = preg_replace('/^https:\/\//', '', $jwtPayload['dest']);
+                } elseif (!empty($jwtPayload['input_data']->shop->domain)) {
+                    $shop = preg_replace('/^https:\/\//', '', $jwtPayload['input_data']->shop->domain);
+                } else {
+                    throw new InvalidJwtPayloadException('Missing shop value in JWT payload');
+                }
+
                 if ($isOnline) {
                     $currentSessionId = self::getJwtSessionId($shop, $jwtPayload['sub']);
                 } else {

--- a/src/Exception/InvalidJwtPayloadException.php
+++ b/src/Exception/InvalidJwtPayloadException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Exception;
+
+class InvalidJwtPayloadException extends \Exception
+{
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Shopify issues an incomplete token/JWT payload from Checkout::PostPurchase::ShouldRender & Checkout::PostPurchase::Render methods on the Post-Purchase Extension.

The "dest" attribute is missing on the JWT payload and should contain the shop domain, so it throws an exception on the Get Current Session ID on the OAuth Process (Class: Shopify\Auth\OAuth, Method: getCurrentSessionId).

I related more details [here](https://community.shopify.com/c/shopify-apis-and-sdks/get-jwt-session-token-in-post-purchase-extension/td-p/1383130).


### WHAT is this pull request doing?

Workaround to get the shop domain from "input_data" attribute from JWT.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
