### PR TITLE
getJsonResponseBodyName is now an array

### DIFF
--- a/src/Rest/Admin2022_10/AssignedFulfillmentOrder.php
+++ b/src/Rest/Admin2022_10/AssignedFulfillmentOrder.php
@@ -33,11 +33,13 @@ class AssignedFulfillmentOrder extends Base
     /**
 
      *
-     * @return string
+     * @return string[]
      */
-    protected static function getJsonResponseBodyName(): string
+    protected static function getJsonResponseBodyNames(): array
     {
-        return "fulfillment_order";
+        return [
+            "fulfillment_order"
+        ];
     }
 
     /**

--- a/src/Rest/Admin2022_10/CustomerAddress.php
+++ b/src/Rest/Admin2022_10/CustomerAddress.php
@@ -55,6 +55,19 @@ class CustomerAddress extends Base
     }
 
     /**
+
+     *
+     * @return string[]
+     */
+    protected static function getJsonResponseBodyNames(): array
+    {
+        return [
+            "customer_address",
+            "address"
+        ];
+    }
+
+    /**
      * @param Session $session
      * @param int|string $id
      * @param array $urlIds Allowed indexes:

--- a/src/Rest/Admin2022_10/FulfillmentRequest.php
+++ b/src/Rest/Admin2022_10/FulfillmentRequest.php
@@ -26,6 +26,19 @@ class FulfillmentRequest extends Base
     ];
 
     /**
+
+     *
+     * @return string[]
+     */
+    protected static function getJsonResponseBodyNames(): array
+    {
+        return [
+            "submitted_fulfillment_order",
+            "fulfillment_order"
+        ];
+    }
+
+    /**
      * @param mixed[] $params Allowed indexes:
      *     message
      * @param array|string $body

--- a/src/Rest/Admin2022_10/OrderRisk.php
+++ b/src/Rest/Admin2022_10/OrderRisk.php
@@ -49,11 +49,13 @@ class OrderRisk extends Base
     /**
 
      *
-     * @return string
+     * @return string[]
      */
-    protected static function getJsonResponseBodyName(): string
+    protected static function getJsonResponseBodyNames(): array
     {
-        return "risk";
+        return [
+            "risk"
+        ];
     }
 
     /**

--- a/src/Rest/Admin2023_01/AssignedFulfillmentOrder.php
+++ b/src/Rest/Admin2023_01/AssignedFulfillmentOrder.php
@@ -33,11 +33,13 @@ class AssignedFulfillmentOrder extends Base
     /**
 
      *
-     * @return string
+     * @return string[]
      */
-    protected static function getJsonResponseBodyName(): string
+    protected static function getJsonResponseBodyNames(): array
     {
-        return "fulfillment_order";
+        return [
+            "fulfillment_order"
+        ];
     }
 
     /**

--- a/src/Rest/Admin2023_01/CustomerAddress.php
+++ b/src/Rest/Admin2023_01/CustomerAddress.php
@@ -55,6 +55,19 @@ class CustomerAddress extends Base
     }
 
     /**
+
+     *
+     * @return string[]
+     */
+    protected static function getJsonResponseBodyNames(): array
+    {
+        return [
+            "customer_address",
+            "address"
+        ];
+    }
+
+    /**
      * @param Session $session
      * @param int|string $id
      * @param array $urlIds Allowed indexes:

--- a/src/Rest/Admin2023_01/FulfillmentRequest.php
+++ b/src/Rest/Admin2023_01/FulfillmentRequest.php
@@ -26,6 +26,19 @@ class FulfillmentRequest extends Base
     ];
 
     /**
+
+     *
+     * @return string[]
+     */
+    protected static function getJsonResponseBodyNames(): array
+    {
+        return [
+            "submitted_fulfillment_order",
+            "fulfillment_order"
+        ];
+    }
+
+    /**
      * @param mixed[] $params Allowed indexes:
      *     message
      * @param array|string $body

--- a/src/Rest/Admin2023_01/OrderRisk.php
+++ b/src/Rest/Admin2023_01/OrderRisk.php
@@ -49,11 +49,13 @@ class OrderRisk extends Base
     /**
 
      *
-     * @return string
+     * @return string[]
      */
-    protected static function getJsonResponseBodyName(): string
+    protected static function getJsonResponseBodyNames(): array
     {
-        return "risk";
+        return [
+            "risk"
+        ];
     }
 
     /**

--- a/src/Rest/Admin2023_04/AssignedFulfillmentOrder.php
+++ b/src/Rest/Admin2023_04/AssignedFulfillmentOrder.php
@@ -33,11 +33,13 @@ class AssignedFulfillmentOrder extends Base
     /**
 
      *
-     * @return string
+     * @return string[]
      */
-    protected static function getJsonResponseBodyName(): string
+    protected static function getJsonResponseBodyNames(): array
     {
-        return "fulfillment_order";
+        return [
+            "fulfillment_order"
+        ];
     }
 
     /**

--- a/src/Rest/Admin2023_04/CustomerAddress.php
+++ b/src/Rest/Admin2023_04/CustomerAddress.php
@@ -55,6 +55,19 @@ class CustomerAddress extends Base
     }
 
     /**
+
+     *
+     * @return string[]
+     */
+    protected static function getJsonResponseBodyNames(): array
+    {
+        return [
+            "customer_address",
+            "address"
+        ];
+    }
+
+    /**
      * @param Session $session
      * @param int|string $id
      * @param array $urlIds Allowed indexes:

--- a/src/Rest/Admin2023_04/FulfillmentRequest.php
+++ b/src/Rest/Admin2023_04/FulfillmentRequest.php
@@ -26,6 +26,19 @@ class FulfillmentRequest extends Base
     ];
 
     /**
+
+     *
+     * @return string[]
+     */
+    protected static function getJsonResponseBodyNames(): array
+    {
+        return [
+            "submitted_fulfillment_order",
+            "fulfillment_order"
+        ];
+    }
+
+    /**
      * @param mixed[] $params Allowed indexes:
      *     message
      * @param array|string $body

--- a/src/Rest/Admin2023_04/OrderRisk.php
+++ b/src/Rest/Admin2023_04/OrderRisk.php
@@ -49,11 +49,13 @@ class OrderRisk extends Base
     /**
 
      *
-     * @return string
+     * @return string[]
      */
-    protected static function getJsonResponseBodyName(): string
+    protected static function getJsonResponseBodyNames(): array
     {
-        return "risk";
+        return [
+            "risk"
+        ];
     }
 
     /**

--- a/src/Rest/Admin2023_07/AssignedFulfillmentOrder.php
+++ b/src/Rest/Admin2023_07/AssignedFulfillmentOrder.php
@@ -33,11 +33,13 @@ class AssignedFulfillmentOrder extends Base
     /**
 
      *
-     * @return string
+     * @return string[]
      */
-    protected static function getJsonResponseBodyName(): string
+    protected static function getJsonResponseBodyNames(): array
     {
-        return "fulfillment_order";
+        return [
+            "fulfillment_order"
+        ];
     }
 
     /**

--- a/src/Rest/Admin2023_07/CustomerAddress.php
+++ b/src/Rest/Admin2023_07/CustomerAddress.php
@@ -55,6 +55,19 @@ class CustomerAddress extends Base
     }
 
     /**
+
+     *
+     * @return string[]
+     */
+    protected static function getJsonResponseBodyNames(): array
+    {
+        return [
+            "customer_address",
+            "address"
+        ];
+    }
+
+    /**
      * @param Session $session
      * @param int|string $id
      * @param array $urlIds Allowed indexes:

--- a/src/Rest/Admin2023_07/FulfillmentRequest.php
+++ b/src/Rest/Admin2023_07/FulfillmentRequest.php
@@ -26,6 +26,19 @@ class FulfillmentRequest extends Base
     ];
 
     /**
+
+     *
+     * @return string[]
+     */
+    protected static function getJsonResponseBodyNames(): array
+    {
+        return [
+            "submitted_fulfillment_order",
+            "fulfillment_order"
+        ];
+    }
+
+    /**
      * @param mixed[] $params Allowed indexes:
      *     message
      * @param array|string $body

--- a/src/Rest/Admin2023_07/OrderRisk.php
+++ b/src/Rest/Admin2023_07/OrderRisk.php
@@ -49,11 +49,13 @@ class OrderRisk extends Base
     /**
 
      *
-     * @return string
+     * @return string[]
      */
-    protected static function getJsonResponseBodyName(): string
+    protected static function getJsonResponseBodyNames(): array
     {
-        return "risk";
+        return [
+            "risk"
+        ];
     }
 
     /**


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/shopify-api-php/issues/258
Also FulfillmentRequest wouldn't have returned an object upon save, now it will

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

We are making `getJsonResponseBodyName` an array to accept multiple possibilities that the API returns. This will let us resolve a few issues that we've faced before with our rest client
## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
