### PR TITLE
[Feature] Improve Webhook ProcessResponse to feel more outcome agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 - [#297](https://github.com/Shopify/shopify-api-php/pull/297) [Patch] Fix CustomerAddress methods, FulfillmentRequest save method
+- [#298](https://github.com/Shopify/shopify-api-php/pull/298) [Minor] Add a body field to the Webhook ProcessResponse class
 
 ## v5.1.0 - 2023-07-11
 

--- a/src/Webhooks/Handler.php
+++ b/src/Webhooks/Handler.php
@@ -13,5 +13,5 @@ interface Handler
      * @param string $shop  The shop that triggered the event
      * @param array  $body  The payload of the webhook request from Shopify
      */
-    public function handle(string $topic, string $shop, array $body): void;
+    public function handle(string $topic, string $shop, array $body);
 }

--- a/src/Webhooks/ProcessResponse.php
+++ b/src/Webhooks/ProcessResponse.php
@@ -7,14 +7,15 @@ namespace Shopify\Webhooks;
 final class ProcessResponse
 {
     /** @var bool */
-    private $success;
+    private bool $success;
     /** @var string|null */
-    private $errorMessage = null;
+    private string|null $errorMessage = null;
+    /** @var mixed */
+    private mixed $body = null;
 
-    public function __construct(bool $success, ?string $errorMessage = null)
+    public function __construct(bool $success)
     {
         $this->success = $success;
-        $this->errorMessage = $errorMessage;
     }
 
     /**
@@ -35,5 +36,41 @@ final class ProcessResponse
     public function getErrorMessage(): ?string
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * Sets the error message.
+     *
+     * @param string $errorMessage
+     * @return ProcessResponse
+     */
+    public function setErrorMessage(string $errorMessage): ProcessResponse
+    {
+        $this->errorMessage = $errorMessage;
+
+        return $this;
+    }
+
+    /**
+     * Returns the response, if the webhook handler has provided it.
+     *
+     * @return mixed
+     */
+    public function getBody(): mixed
+    {
+        return $this->body;
+    }
+
+    /**
+     * Sets the response.
+     *
+     * @param mixed $body
+     * @return ProcessResponse
+     */
+    public function setBody(mixed $body): ProcessResponse
+    {
+        $this->body = $body;
+
+        return $this;
     }
 }

--- a/src/Webhooks/Registry.php
+++ b/src/Webhooks/Registry.php
@@ -152,10 +152,12 @@ final class Registry
         }
 
         try {
-            $handler->handle($topic, $shop, $body);
-            $response = new ProcessResponse(true);
+            $handlerResponse = $handler->handle($topic, $shop, $body);
+            $response = (new ProcessResponse(true))
+                ->setBody($handlerResponse);
         } catch (Exception $error) {
-            $response = new ProcessResponse(false, $error->getMessage());
+            $response = (new ProcessResponse(false))
+                ->setErrorMessage($error->getMessage());
         }
 
         return $response;

--- a/tests/Webhooks/ProcessResponseTest.php
+++ b/tests/Webhooks/ProcessResponseTest.php
@@ -14,9 +14,43 @@ final class ProcessResponseTest extends BaseTestCase
         $response = new ProcessResponse(true);
         $this->assertTrue($response->isSuccess());
         $this->assertNull($response->getErrorMessage());
+        $this->assertNull($response->getBody());
 
-        $response = new ProcessResponse(false, 'Something went wrong');
+        $response = new ProcessResponse(false);
+        $response->setErrorMessage('Something went wrong');
         $this->assertFalse($response->isSuccess());
         $this->assertEquals('Something went wrong', $response->getErrorMessage());
+        $this->assertNull($response->getBody());
+
+        $response = new ProcessResponse(false);
+        $response->setErrorMessage('Something went wrong');
+        $response->setBody('A String Response');
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals('Something went wrong', $response->getErrorMessage());
+        $this->assertEquals('A String Response', $response->getBody());
+
+        $response = new ProcessResponse(true);
+        $response->setBody('A String Response');
+        $this->assertTrue($response->isSuccess());
+        $this->assertEquals(null, $response->getErrorMessage());
+        $this->assertEquals('A String Response', $response->getBody());
+
+        $response = new ProcessResponse(false);
+        $response->setBody('A String Response');
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals(null, $response->getErrorMessage());
+        $this->assertEquals('A String Response', $response->getBody());
+
+        $response = new ProcessResponse(true);
+        $response->setBody(['Some Data in an Array']);
+        $this->assertTrue($response->isSuccess());
+        $this->assertEquals(null, $response->getErrorMessage());
+        $this->assertEquals(['Some Data in an Array'], $response->getBody());
+
+        $response = new ProcessResponse(true);
+        $response->setBody(123456789);
+        $this->assertTrue($response->isSuccess());
+        $this->assertEquals(null, $response->getErrorMessage());
+        $this->assertEquals(123456789, $response->getBody());
     }
 }


### PR DESCRIPTION
### WHY are these changes introduced?
This is just a QOL improvement which allows the webhook handler to return mixed typed data.

Currently the ProcessResponse is only set up to return an exception message if it fails but it would be useful to get data back when it succeeds too 

### WHAT is this pull request doing?
Added a field called body onto the ProcessResponse object which is handled within the webhook registry

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
