### PR TITLE
Add deletion and raw http endpoint urls for Webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [#2xx](https://github.com/Shopify/shopify-api-php/pull/2xx) [Minor] Raw URLs for Webhooks, deletion on empty path
 - [#297](https://github.com/Shopify/shopify-api-php/pull/297) [Patch] Fix CustomerAddress methods, FulfillmentRequest save method
 
 ## v5.1.0 - 2023-07-11

--- a/src/Webhooks/Delivery/HttpDelivery.php
+++ b/src/Webhooks/Delivery/HttpDelivery.php
@@ -13,9 +13,7 @@ class HttpDelivery extends DeliveryMethod
      */
     public function getCallbackAddress(string $path): string
     {
-        $rv =  'https://' . Context::$HOST_NAME . '/' . ltrim($path, '/');
-        var_dump($rv);
-        return $rv;
+        return 'https://' . Context::$HOST_NAME . '/' . ltrim($path, '/');
     }
 
     /**

--- a/src/Webhooks/Delivery/HttpDelivery.php
+++ b/src/Webhooks/Delivery/HttpDelivery.php
@@ -13,7 +13,9 @@ class HttpDelivery extends DeliveryMethod
      */
     public function getCallbackAddress(string $path): string
     {
-        return 'https://' . Context::$HOST_NAME . '/' . ltrim($path, '/');
+        $rv =  'https://' . Context::$HOST_NAME . '/' . ltrim($path, '/');
+        var_dump($rv);
+        return $rv;
     }
 
     /**

--- a/src/Webhooks/DeliveryMethod.php
+++ b/src/Webhooks/DeliveryMethod.php
@@ -80,6 +80,27 @@ abstract class DeliveryMethod
         QUERY;
     }
 
+    public function buildDeleteQuery(
+        string $topic,
+        string $callbackAddress,
+        string $webhookId
+    ): string {
+        $mutationName = $this->getDeletionMutationName();
+        $identifier = "id: \"$webhookId\"";
+
+        return <<<QUERY
+        mutation webhookSubscription {
+            $mutationName($identifier) {
+                userErrors {
+                    field
+                    message
+                }
+                deletedWebhookSubscriptionId
+            }
+        }
+        QUERY;
+    }
+
     /**
      * Checks if the given result was successful.
      *
@@ -90,6 +111,7 @@ abstract class DeliveryMethod
      */
     public function isSuccess(array $result, ?string $webhookId = null): bool
     {
-        return !empty($result['data'][$this->getMutationName($webhookId)]['webhookSubscription']);
+        return !empty($result['data'][$this->getMutationName($webhookId)]['webhookSubscription'])
+            || !empty($result['data'][$this->getDeletionMutationName()]['deletedWebhookSubscriptionId']);
     }
 }

--- a/src/Webhooks/Registry.php
+++ b/src/Webhooks/Registry.php
@@ -15,6 +15,7 @@ use Shopify\Exception\WebhookRegistrationException;
 use Shopify\Utils;
 use Shopify\Webhooks\Delivery\EventBridge;
 use Shopify\Webhooks\Delivery\HttpDelivery;
+use Shopify\Webhooks\Delivery\HttpDeliveryRaw;
 use Shopify\Webhooks\Delivery\PubSub;
 
 /**
@@ -25,6 +26,7 @@ final class Registry
     public const DELIVERY_METHOD_HTTP = 'http';
     public const DELIVERY_METHOD_EVENT_BRIDGE = 'eventbridge';
     public const DELIVERY_METHOD_PUB_SUB = 'pubsub';
+    public const DELIVERY_METHOD_RAW = 'raw';
 
     /** @var Handler[] */
     private static $REGISTRY = [];
@@ -87,6 +89,9 @@ final class Registry
             case self::DELIVERY_METHOD_HTTP:
                 $method = new HttpDelivery();
                 break;
+            case self::DELIVERY_METHOD_RAW:
+                $method = new HttpDeliveryRaw();
+                break;
             default:
                 throw new InvalidArgumentException("Unrecognized delivery method '$deliveryMethod'");
         }
@@ -101,6 +106,20 @@ final class Registry
             $callbackAddress,
             $method
         );
+
+        // unregister if empty path is passed (not sure what $webhookId is
+        // when no registration exists, but assuming it will be false-ish
+        if (empty($path) && $webhookId) {
+            $body = self::sendDeleteRequest(
+                $client,
+                $topic,
+                $callbackAddress,
+                $method,
+                $webhookId
+            );
+            $registered = $method->isSuccess($body, $webhookId);
+            return new RegisterResponse($registered, $body);
+        }
 
         $registered = true;
         $body = null;
@@ -187,6 +206,7 @@ final class Registry
         $checkStatusCode = $checkResponse->getStatusCode();
         $checkBody = $checkResponse->getDecodedBody();
 
+        print_r($checkBody);
         if ($checkStatusCode !== 200) {
             throw new WebhookRegistrationException(
                 <<<ERROR
@@ -231,6 +251,46 @@ final class Registry
 
         $statusCode = $registerResponse->getStatusCode();
         $body = $registerResponse->getDecodedBody();
+        if ($statusCode !== 200) {
+            throw new WebhookRegistrationException(
+                <<<ERROR
+                Failed to register webhook with Shopify (status code $statusCode):
+                $body
+                ERROR
+            );
+        }
+
+        return $body;
+    }
+
+    /**
+     * Deletes a webhook subscription in Shopify by firing the appropriate GraphQL query.
+     *
+     * @param \Shopify\Clients\Graphql         $client
+     * @param string                           $topic
+     * @param string                           $callbackAddress
+     * @param \Shopify\Webhooks\DeliveryMethod $deliveryMethod
+     * @param string|null                      $webhookId
+     *
+     * @return array
+     *
+     * @throws \Shopify\Exception\HttpRequestException
+     * @throws \Shopify\Exception\MissingArgumentException
+     * @throws \Shopify\Exception\WebhookRegistrationException
+     */
+    private static function sendDeleteRequest(
+        Graphql $client,
+        string $topic,
+        string $callbackAddress,
+        DeliveryMethod $deliveryMethod,
+        string $webhookId
+    ): array {
+        $deleteResponse = $client->query(
+            data: $deliveryMethod->buildDeleteQuery($topic, $callbackAddress, $webhookId),
+        );
+
+        $statusCode = $deleteResponse->getStatusCode();
+        $body = $deleteResponse->getDecodedBody();
         if ($statusCode !== 200) {
             throw new WebhookRegistrationException(
                 <<<ERROR


### PR DESCRIPTION
### WHY are these changes introduced?

I couldn't add a webhook, because it insists on making all HttpDelivery webhooks a path of Context::$HOST_NAME (which was myshop.myshopify.com), and I wanted a webhook on **my** server.

```php
    public function getCallbackAddress(string $path): string
    {
        return 'https://' . Context::$HOST_NAME . '/' . ltrim($path, '/');
    }
```

I also couldn't delete a webhook.

### WHAT is this pull request doing?

Added a new enum to Webhooks::Registry::register

```php
            case self::DELIVERY_METHOD_RAW:
                $method = new HttpDeliveryRaw();
                break;
```

which doesn't try and get smart with the provided url

```php
    public function getCallbackAddress(string $path): string
    {
        return $path;
    }
````

To allow deletion of webhooks with the maximum code re-use, I modified Webhooks::Registry::register to equate an empty `$path` with a request to delete the webhook.

```php
        if (empty($path) && $webhookId) {
            $body = self::sendDeleteRequest(
                $client,
                $topic,
                $callbackAddress,
                $method,
                $webhookId
            );
            $registered = $method->isSuccess($body, $webhookId);
            return new RegisterResponse($registered, $body);
        }
```

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [-] I have added/updated tests for this change
 *  There are no existing tests for DELIVERY_METHOD_HTTP, so no reason to add any for DELIVERY_METHOD_RAW
 *  Possibly there should be a test written for the deletion functionality, and I will do so if this PR receives tentative approval.
   
- [ ] I have updated the documentation for public APIs from the library (if applicable)
There's documentation?