### PR TITLE
Adding support version ^2.0 for psr/http-message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "guzzlehttp/guzzle": "^7.0",
         "guzzlehttp/psr7": "^2.0",
         "psr/http-client": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0 ",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "ramsey/uuid": "^4.1"
     },


### PR DESCRIPTION
Adding support version ^2.0 for psr/http-message

### WHY are these changes introduced?

[Fixes #273](https://github.com/Shopify/shopify-api-php/issues/273) 

I tried to install bundle in one of my projects but I can not because I have psr/http-message in version ^2.0

### WHAT is this pull request doing?

Now we can use for version ^2.0

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
