### PR TITLE
[Feature] Improve API deprecation logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     env:
-      PHP_INI_VALUES: assert.exception=1, zend.assertions=1
+      PHP_INI_VALUES: assert.exception=1, zend.assertions=1, apc.enable_cli=1
     strategy:
       fail-fast: false
       matrix:
@@ -21,6 +21,7 @@ jobs:
           tools: composer:v2, phpcs
           coverage: xdebug
           ini-values: ${{ env.PHP_INI_VALUES }}
+          extensions: apcu
 
       - name: Install dependencies with composer
         run: composer update --no-ansi --no-interaction --no-progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [Patch] Avoid writing to system temporary directory when an API deprecation is encountered
+
 ## v5.3.0 - 2024-01-10
 
 - [#318](https://github.com/Shopify/shopify-api-php/pull/318) [Minor] Adding support for 2024-01 API version

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -1,0 +1,7 @@
+{
+  "symbol-whitelist" : [
+    "apcu_enabled",
+    "apcu_fetch",
+    "apcu_store"
+  ]
+}

--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,15 @@
         "ramsey/uuid": "^4.1"
     },
     "require-dev": {
+        "ext-apcu": "*",
         "ergebnis/composer-normalize": "^2.30",
         "maglnet/composer-require-checker": "^3.0 || ^4.0",
         "mikey179/vfsstream": "^1.6",
         "phpunit/phpunit": "^9",
         "squizlabs/php_codesniffer": "^3.6"
+    },
+    "suggest": {
+        "ext-apcu": "Log fewer API deprecation warnings"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93ba78898d3f08b785fb96d120f43e95",
+    "content-hash": "b1f586d61b3a6c89e4f349f8dd90d343",
     "packages": [
         {
             "name": "brick/math",
@@ -4278,6 +4278,8 @@
         "ext-json": "*",
         "ext-mbstring": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {
+        "ext-apcu": "*"
+    },
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -274,27 +274,14 @@ class Http
      */
     private function shouldLogApiDeprecation(): bool
     {
-        $warningFilePath = $this->getApiDeprecationTimestampFilePath();
-
-        $lastWarning = null;
-        if (file_exists($warningFilePath)) {
-            $lastWarning = (int)(file_get_contents($warningFilePath));
-        }
-
-        if (time() - $lastWarning < self::DEPRECATION_ALERT_SECONDS) {
-            $result = false;
-        } else {
-            $result = true;
-            file_put_contents($warningFilePath, time());
-        }
-
-        return $result;
+        return true;
     }
 
     /**
      * Fetches the path to the file holding the timestamp of the last API deprecation warning we logged.
      *
      * @codeCoverageIgnore This is mocked in tests so we don't use real files
+     * @deprecated 5.3.1 This method is no longer used internally.
      */
     public function getApiDeprecationTimestampFilePath(): string
     {

--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -26,6 +26,8 @@ class Http
     /** @var string */
     private $domain;
 
+    private int $lastApiDeprecationWarning = 0;
+
     public function __construct(string $domain)
     {
         $this->domain = $domain;
@@ -274,6 +276,13 @@ class Http
      */
     private function shouldLogApiDeprecation(): bool
     {
+        $secondsSinceLastAlert = time() - $this->lastApiDeprecationWarning;
+        if ($secondsSinceLastAlert < self::DEPRECATION_ALERT_SECONDS) {
+            return false;
+        }
+
+        $this->lastApiDeprecationWarning = time();
+
         return true;
     }
 

--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -21,7 +21,7 @@ class Http
     public const DATA_TYPE_GRAPHQL = 'application/graphql';
 
     private const RETRIABLE_STATUS_CODES = [429, 500];
-    private const DEPRECATION_ALERT_SECONDS = 60;
+    private const DEPRECATION_ALERT_SECONDS = 3600;
 
     /** @var string */
     private $domain;

--- a/tests/Clients/HttpTest.php
+++ b/tests/Clients/HttpTest.php
@@ -555,7 +555,7 @@ final class HttpTest extends BaseTestCase
         $mockedClient->get('test/path');
         $this->assertCount(1, $testLogger->records);
 
-        // We only log once every minute, so simulate more time than having elapsed
+        // We only log once every hour, so simulate more time than having elapsed
         $reflector = new ReflectionProperty(Http::class, 'lastApiDeprecationWarning');
         $reflector->setValue($mockedClient, time() - 7200);
 

--- a/tests/Clients/HttpTest.php
+++ b/tests/Clients/HttpTest.php
@@ -442,16 +442,13 @@ final class HttpTest extends BaseTestCase
 
     public function testDeprecatedRequestsAreLoggedWithinLimit()
     {
-        $vfsRoot = vfsStream::setup('test');
+        $this->markTestSkipped('For now there is no back-off implemented');
 
         /** @var MockObject|Http */
         $mockedClient = $this->getMockBuilder(Http::class)
             ->setConstructorArgs([$this->domain])
-            ->onlyMethods(['getApiDeprecationTimestampFilePath'])
+            ->onlyMethods([])
             ->getMock();
-        $mockedClient->expects($this->exactly(2))
-            ->method('getApiDeprecationTimestampFilePath')
-            ->willReturn(vfsStream::url('test/timestamp_file'));
 
         $testLogger = new LogMock();
         Context::$LOGGER = $testLogger;
@@ -469,31 +466,28 @@ final class HttpTest extends BaseTestCase
             )
         ]);
 
-        $this->assertFalse($vfsRoot->hasChild('timestamp_file'));
+        // TODO: assert that no flag/value exists for "last deprecation warning"
         $mockedClient->get('test/path');
 
-        $this->assertTrue($vfsRoot->hasChild('timestamp_file'));
+        // TODO: assert that a flag/value exists for "last deprecation warning"
         $this->assertTrue($testLogger->hasWarningThatContains('API Deprecation notice'));
         $this->assertCount(1, $testLogger->recordsByLevel[LogLevel::WARNING]);
 
         $mockedClient->get('test/path');
 
-        $this->assertTrue($vfsRoot->hasChild('timestamp_file'));
+        // TODO: assert that a flag/value exists for "last deprecation warning"
         $this->assertCount(1, $testLogger->recordsByLevel[LogLevel::WARNING]);
     }
 
     public function testDeprecationLogBackoffPeriod()
     {
-        vfsStream::setup('test');
+        $this->markTestSkipped('For now there is no back-off implemented');
 
         /** @var MockObject|Http */
         $mockedClient = $this->getMockBuilder(Http::class)
             ->setConstructorArgs([$this->domain])
-            ->onlyMethods(['getApiDeprecationTimestampFilePath'])
+            ->onlyMethods([])
             ->getMock();
-        $mockedClient->expects($this->exactly(3))
-            ->method('getApiDeprecationTimestampFilePath')
-            ->willReturn(vfsStream::url('test/timestamp_file'));
 
         $testLogger = new LogMock();
         Context::$LOGGER = $testLogger;
@@ -525,7 +519,7 @@ final class HttpTest extends BaseTestCase
         $this->assertCount(1, $testLogger->records);
 
         // We only log once every minute, so simulate more time than having elapsed
-        file_put_contents(vfsStream::url('test/timestamp_file'), time() - 70);
+        // TODO: reset the flag/value for "last deprecation warning"
 
         $mockedClient->get('test/path');
         $this->assertCount(2, $testLogger->records);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-api-php/issues/245

By default, this library writes a file into the system temporary directory when an API deprecation is encountered. The user that first does so then owns that file, and is typically the only user which is able to write to it. When another user on the same system attempts to use this library, the inability to write to this file can cause significant issues - sometimes leading to a fatal error in that application.

### WHAT is this pull request doing?

This pull request moves this flag from a file on disk to an in-memory store where there are not any permission issues. This can lead to more log entries if APCu is not available.

I have also reduced the alerting frequency from (at most) once per minute to (at most) once per hour. This should reduce the noise for consumers of the library, while still surfacing the deprecation for those who are reviewing their logs.

I have intentionally made these changes in individual commits in order to help reviewers see what has been changed and why.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- ~~Minor: New feature (non-breaking change which adds functionality)~~
- ~~Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)~~

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- ~~I have updated the documentation for public APIs from the library (if applicable)~~
