### PR TITLE
Preparing for release v5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v5.6.0 - 2024-07-02
+
 - [#354](https://github.com/Shopify/shopify-api-php/pull/354) [Minor] Adding support for 2024-07 API version
 
 ## v5.5.1 - 2024-05-24

--- a/src/version.php
+++ b/src/version.php
@@ -1,5 +1,5 @@
 <?php
 
 // @codeCoverageIgnoreStart
-return '5.5.1';
+return '5.6.0';
 // @codeCoverageIgnoreEnd


### PR DESCRIPTION
This PR sets the package up for release v5.6.0, which includes API version 2024-07.