### PR TITLE
fix(array-to-string-conversion): Fix array to string conversion error in webhook registration

### DIFF
--- a/src/Webhooks/Registry.php
+++ b/src/Webhooks/Registry.php
@@ -189,10 +189,10 @@ final class Registry
         $checkResponse = $client->query(data: $method->buildCheckQuery($topic));
 
         $checkStatusCode = $checkResponse->getStatusCode();
-        $checkBody = $checkResponse->getDecodedBody();
-        $checkBodyString = json_encode($checkBody, JSON_PRETTY_PRINT);
+        $checkBody = $checkResponse->getDecodedBody();    
 
         if ($checkStatusCode !== 200) {
+            $checkBodyString = json_encode($checkBody, JSON_PRETTY_PRINT);
             throw new WebhookRegistrationException(
                 <<<ERROR
                 Failed to check if webhook was already registered (status code $checkStatusCode):

--- a/src/Webhooks/Registry.php
+++ b/src/Webhooks/Registry.php
@@ -189,7 +189,7 @@ final class Registry
         $checkResponse = $client->query(data: $method->buildCheckQuery($topic));
 
         $checkStatusCode = $checkResponse->getStatusCode();
-        $checkBody = $checkResponse->getDecodedBody();    
+        $checkBody = $checkResponse->getDecodedBody();
 
         if ($checkStatusCode !== 200) {
             $checkBodyString = json_encode($checkBody, JSON_PRETTY_PRINT);

--- a/src/Webhooks/Registry.php
+++ b/src/Webhooks/Registry.php
@@ -190,12 +190,13 @@ final class Registry
 
         $checkStatusCode = $checkResponse->getStatusCode();
         $checkBody = $checkResponse->getDecodedBody();
+        $checkBodyString = json_encode($checkBody, JSON_PRETTY_PRINT);
 
         if ($checkStatusCode !== 200) {
             throw new WebhookRegistrationException(
                 <<<ERROR
                 Failed to check if webhook was already registered (status code $checkStatusCode):
-                $checkBody
+                $checkBodyString
                 ERROR
             );
         }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

While checking a webhook record, an "Array to string conversion" error was encountered. This error occurs when the code tries to concatenate or output an array directly as a string. In this specific case, the $checkBody variable was being used directly inside a string, causing the error.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This pull request addresses and resolves the "Array to string conversion" error that occurs during the webhook registration check in the application. The error was caused by attempting to concatenate an array directly within a string.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
