### PR TITLE
extend:webhook-deliveries

### DIFF
--- a/src/Webhooks/DeliveryMethod.php
+++ b/src/Webhooks/DeliveryMethod.php
@@ -56,18 +56,21 @@ abstract class DeliveryMethod
      *
      * @return string
      */
-    public function buildRegisterQuery(
-        string $topic,
-        string $callbackAddress,
-        ?string $webhookId = null
-    ): string {
-        $mutationName = $this->getMutationName($webhookId);
-        $identifier = $webhookId ? "id: \"$webhookId\"" : "topic: $topic";
-        $webhookSubscriptionArgs = $this->queryEndpoint($callbackAddress);
+    public function buildRegisterQuery(string $topic, string $callbackAddress, ?string $webhookId, array $fields = [], array $metafieldNamespaces = []): string
+    {
+        $fieldsQuery = !empty($fields) ? 'fields: [' . implode(',', $fields) . ']' : '';
+        $metafieldNamespacesQuery = !empty($metafieldNamespaces) ? 'metafieldNamespaces: [' . implode(',', $metafieldNamespaces) . ']' : '';
 
         return <<<QUERY
-        mutation webhookSubscription {
-            $mutationName($identifier, webhookSubscription: $webhookSubscriptionArgs) {
+        mutation {
+            webhookSubscriptionCreate(
+                topic: "$topic",
+                webhookSubscription: {
+                    callbackUrl: "$callbackAddress"
+                    $fieldsQuery
+                    $metafieldNamespacesQuery
+                }
+            ) {
                 userErrors {
                     field
                     message
@@ -77,8 +80,9 @@ abstract class DeliveryMethod
                 }
             }
         }
-        QUERY;
+    QUERY;
     }
+
 
     /**
      * Checks if the given result was successful.

--- a/src/Webhooks/Registry.php
+++ b/src/Webhooks/Registry.php
@@ -77,7 +77,9 @@ final class Registry
         string $topic,
         string $shop,
         string $accessToken,
-        ?string $deliveryMethod = self::DELIVERY_METHOD_HTTP
+        ?string $deliveryMethod = self::DELIVERY_METHOD_HTTP,
+        array $fields = [],
+        array $metafieldNamespaces = []
     ): RegisterResponse {
         /** @var DeliveryMethod */
         $method = null;
@@ -114,7 +116,9 @@ final class Registry
                 $topic,
                 $callbackAddress,
                 $method,
-                $webhookId
+                $webhookId,
+                $fields,
+                $metafieldNamespaces
             );
             $registered = $method->isSuccess($body, $webhookId);
         }
@@ -228,10 +232,14 @@ final class Registry
         string $topic,
         string $callbackAddress,
         DeliveryMethod $deliveryMethod,
-        ?string $webhookId
+        ?string $webhookId,
+        array $fields = [],
+        array $metafieldNamespaces = []
     ): array {
+        $registerQuery = $deliveryMethod->buildRegisterQuery($topic, $callbackAddress, $webhookId, $fields, $metafieldNamespaces);
+
         $registerResponse = $client->query(
-            data: $deliveryMethod->buildRegisterQuery($topic, $callbackAddress, $webhookId),
+            data: $registerQuery,
         );
 
         $statusCode = $registerResponse->getStatusCode();

--- a/tests/Clients/GraphqlTest.php
+++ b/tests/Clients/GraphqlTest.php
@@ -201,11 +201,12 @@ final class GraphqlTest extends BaseTestCase
     public function testProxyForwardsBodyAsJsonType()
     {
         $queryToProxy = <<<QUERY
+        <<<QUERY
         {
-          "variables": {},
-          "query": "{\nshop {\n    name\n    __typename\n  }\n}"
+            "variables": {},
+            "query": "{\nshop {\n    name\n    __typename\n  }\n}"
         }
-        QUERY;
+        QUERY; // phpcs:ignore
 
         $extraHeaders = ['Extra-Extra' => 'hear_all_about_it'];
         $client = new Graphql($this->domain, 'token');


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #362 <!-- link to issue if one exists -->

<!--
  This pull request addresses the lack of support for specifying fields and metafieldNamespaces in webhook registrations.
  The feature aligns with the Ruby implementation by allowing more granular control over which fields and metafields are included
  in the webhook payload.
-->

### WHAT is this pull request doing?

<!--
  - Adds support for specifying `fields` and `metafieldNamespaces` in the `buildRegisterQuery` method of the `Registry` class.
  - Updates the `buildRegisterQuery` method to construct GraphQL mutations with these new parameters.
  - Ensures the new parameters are properly handled and included in the mutation query string.
-->

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [x] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
