### PR TITLE
[FIX] includeExpired set to false should not automatically return null 

### DIFF
--- a/src/Auth/Session.php
+++ b/src/Auth/Session.php
@@ -145,11 +145,11 @@ class Session
      *
      * @return bool
      */
-    public function isValid(): bool
+    public function isValid(bool $includeExpired = false): bool
     {
         return (Context::$SCOPES->equals($this->scope) &&
             $this->accessToken &&
-            (!$this->expires || ($this->expires > new DateTime()))
+            ($includeExpired || !$this->expires || ($this->expires > new DateTime()))
         );
     }
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -179,7 +179,7 @@ final class Utils
         $sessionId = OAuth::getOfflineSessionId($shop);
         $session = Context::$SESSION_STORAGE->loadSession($sessionId);
 
-        if ($session && !$includeExpired && !$session->isValid()) {
+        if ($session && !$session->isValid($includeExpired)) {
             return null;
         }
 


### PR DESCRIPTION
includeExpired set to false is incorrectly forcing the loadOfflineSession method to always return null. Offline sessions should not be considered invalid automatically if they don't have an expiration date and the property should be used in the valid check to discard expired sessions.

### WHY are these changes introduced?

- Bug not reported for this issue. Identified on production.

- Offline sessions not used even when they exist and token is valid

### WHAT is this pull request doing?

- It fixes the incorrect checks for a Offline Session

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
