### PR TITLE
Cast Content-Length header value to string to avoid psr7 deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 - [Deprecated] This package is deprecated in favor of [`shopify/shopify-app-php`](https://packagist.org/packages/shopify/shopify-app-php), which supports the latest Shopify platform features. It is now marked abandoned via the Composer `abandoned` flag. It will keep working for existing users, but no new features or security fixes are planned. See the [shopify-app-php README](https://github.com/Shopify/shopify-app-php#readme) to upgrade.
+- [Patch] Cast `Content-Length` header value to `string` in `Http::request()` to avoid a `guzzlehttp/psr7` 2.11 deprecation (`Passing int to MessageInterface::withHeader() is deprecated`) and stay compatible with `guzzlehttp/psr7` 3.0
 
 ## v6.1.1 - 2026-03-02
 - [#456](https://github.com/Shopify/shopify-api-php/pull/456) [Patch] Update firebase/php-jwt to ^7.0 to address security vulnerability (GHSA-2x45-7fc3-mxwq)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 - [Deprecated] This package is deprecated in favor of [`shopify/shopify-app-php`](https://packagist.org/packages/shopify/shopify-app-php), which supports the latest Shopify platform features. It is now marked abandoned via the Composer `abandoned` flag. It will keep working for existing users, but no new features or security fixes are planned. See the [shopify-app-php README](https://github.com/Shopify/shopify-app-php#readme) to upgrade.
-- [Patch] Cast `Content-Length` header value to `string` in `Http::request()` to avoid a `guzzlehttp/psr7` 2.11 deprecation (`Passing int to MessageInterface::withHeader() is deprecated`) and stay compatible with `guzzlehttp/psr7` 3.0
+- [#465](https://github.com/Shopify/shopify-api-php/pull/465) [Patch] Cast `Content-Length` header value to `string` in `Http::request()` to avoid a `guzzlehttp/psr7` 2.11 deprecation (`Passing int to MessageInterface::withHeader() is deprecated`) and stay compatible with `guzzlehttp/psr7` 3.0
 
 ## v6.1.1 - 2026-03-02
 - [#456](https://github.com/Shopify/shopify-api-php/pull/456) [Patch] Update firebase/php-jwt to ^7.0 to address security vulnerability (GHSA-2x45-7fc3-mxwq)

--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -207,7 +207,7 @@ class Http
             $request = $request
                 ->withBody($stream)
                 ->withHeader(HttpHeaders::CONTENT_TYPE, $dataType)
-                ->withHeader(HttpHeaders::CONTENT_LENGTH, mb_strlen($bodyString));
+                ->withHeader(HttpHeaders::CONTENT_LENGTH, (string) mb_strlen($bodyString));
         }
 
         $currentTries = 0;


### PR DESCRIPTION
### WHY are these changes introduced?

`guzzlehttp/psr7` 2.11 deprecates passing a non-string value to `MessageInterface::withHeader()`, and 3.0 will require `string|string[]`:

```
Since guzzlehttp/psr7 2.11: Passing int to MessageInterface::withHeader() is deprecated; guzzlehttp/psr7 3.0 requires string|string[].
```

In `Http::request()`, the `Content-Length` header is set to the return value of `mb_strlen($bodyString)`, which is an `int`. As a result, **every request that includes a body (POST/PUT)** emits this deprecation. On production this fills logs/APM with deprecation warnings, and it will become a hard incompatibility once `guzzlehttp/psr7` 3.0 is adopted.

### WHAT is this pull request doing?

Casts the `Content-Length` header value to `string` so it satisfies the PSR-7 `MessageInterface::withHeader()` contract.

```diff
-                ->withHeader(HttpHeaders::CONTENT_LENGTH, mb_strlen($bodyString));
+                ->withHeader(HttpHeaders::CONTENT_LENGTH, (string) mb_strlen($bodyString));
```

This is behavior-preserving: `psr7` already coerces the value to a string internally, so the serialized header (`Content-Length: <n>`) is unchanged. The existing `Http`/`Rest`/`Graphql` client tests that assert `Content-Length: <length>` continue to pass.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change <!-- Existing Http/Rest/Graphql client tests already assert the Content-Length header; the cast is behavior-preserving so no new test is required. -->
- [ ] I have updated the documentation for public APIs from the library (if applicable)
