### PR TITLE
Deprecate in favor of shopify/shopify-app-php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- [Deprecated] This package is deprecated in favor of [`shopify/shopify-app-php`](https://packagist.org/packages/shopify/shopify-app-php), which supports the latest Shopify platform features. It is now marked abandoned via the Composer `abandoned` flag. It will keep working for existing users, but no new features or security fixes are planned. See the [shopify-app-php README](https://github.com/Shopify/shopify-app-php#readme) to upgrade.
 
 ## v6.1.1 - 2026-03-02
 - [#456](https://github.com/Shopify/shopify-api-php/pull/456) [Patch] Update firebase/php-jwt to ^7.0 to address security vulnerability (GHSA-2x45-7fc3-mxwq)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-**Note:** We've released a new experimental package for PHP. Please read [rethinking our support for PHP & Python packages](https://community.shopify.dev/t/rethinking-support-for-php-python-packages/28325). The new PHP package supports the latest Shopify platform features and we'd love your feedback. Please see [shopify-app-php](https://packagist.org/packages/shopify/shopify-app-php) to get started.
+> [!WARNING]
+> **This package is deprecated and no longer maintained.** Use [`shopify/shopify-app-php`](https://packagist.org/packages/shopify/shopify-app-php) instead. It supports the latest Shopify platform features. For background, see [rethinking our support for PHP & Python packages](https://community.shopify.dev/t/rethinking-support-for-php-python-packages/28325).
 
 # Shopify API Library for PHP
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!WARNING]
-> **This package is deprecated and no longer maintained.** Use [`shopify/shopify-app-php`](https://packagist.org/packages/shopify/shopify-app-php) instead. It supports the latest Shopify platform features. For background, see [rethinking our support for PHP & Python packages](https://community.shopify.dev/t/rethinking-support-for-php-python-packages/28325).
+> **This package is deprecated and no longer maintained.** Use [`shopify/shopify-app-php`](https://packagist.org/packages/shopify/shopify-app-php) instead, which supports the latest Shopify platform features. It will keep working for existing users, but no new features or security fixes are planned. See the [`shopify-app-php` README](https://github.com/Shopify/shopify-app-php#readme) to upgrade. For background, see [rethinking our support for PHP & Python packages](https://community.shopify.dev/t/rethinking-support-for-php-python-packages/28325).
 
 # Shopify API Library for PHP
 

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Shopify API Library for PHP",
     "license": "MIT",
     "type": "library",
+    "abandoned": "shopify/shopify-app-php",
     "keywords": [
         "shopify",
         "node",


### PR DESCRIPTION
## What

Marks this package as deprecated now that `shopify/shopify-app-php` has reached v1.0 GA.

- Adds the Composer `"abandoned": "shopify/shopify-app-php"` flag, so Packagist shows the abandoned banner and `composer` warns on install/update.
- Updates the README notice to a clear deprecation, including that the package keeps working but gets no new features or security fixes, plus a migration pointer.
- Adds a CHANGELOG entry under Unreleased.

## Why

The new `shopify-app-php` package supports the latest Shopify platform features and is now GA. This is the formal deprecation signal for the old library.

## Activating it (for whoever owns the Packagist listing)

Packagist syncs the `abandoned` flag from the default branch, but per-version metadata only carries the flag on the version whose composer.json had it. To flip the whole package immediately:
1. Hit the **Abandon** button in the Packagist package settings UI (points to `shopify/shopify-app-php`), and
2. Cut a release so the flag lands on a tagged version too.